### PR TITLE
feat(v2): CSP presets, helpers, and reporting (PR 2/3)

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ var crypto = require("crypto");
 
 var SELF = "'self'";
 var NONE = "'none'";
+var STRICT_DYNAMIC = "'strict-dynamic'";
+
+var SUPPORTED_PROFILES = ["strict", "strict-dynamic", "development"];
+var SUPPORTED_HASH_ALGORITHMS = ["sha256", "sha384", "sha512"];
 
 var DEFAULT_OPTION_ARRAYS = [
   "scripts",
@@ -33,14 +37,144 @@ var DEFAULT_OPTION_ARRAYS = [
   "reportTo",
 ];
 
+var DEVELOPMENT_CONNECT_SOURCES = [
+  "ws:",
+  "wss:",
+  "http://localhost:*",
+  "https://localhost:*",
+];
+
 module.exports = {
   generateNonce: generateNonce,
+  formatNonce: formatNonce,
+  hashSource: hashSource,
   getDirectives: getDirectives,
+  getReportingEndpointsHeader: getReportingEndpointsHeader,
+  createNonceMiddleware: createNonceMiddleware,
+  nonceDirective: nonceDirective,
 };
 
 function generateNonce(byteLength) {
   var length = byteLength === undefined ? 16 : byteLength;
   return crypto.randomBytes(length).toString("hex");
+}
+
+function formatNonce(nonce) {
+  if (nonce === undefined || nonce === null || nonce === "") {
+    throw new TypeError("nonce is required");
+  }
+
+  if (nonce.charAt(0) === "'" && nonce.charAt(nonce.length - 1) === "'") {
+    return nonce;
+  }
+
+  var value = String(nonce).replace(/^nonce-/, "");
+  return "'nonce-" + value + "'";
+}
+
+function hashSource(content, algorithm) {
+  var algo = algorithm || "sha256";
+
+  if (SUPPORTED_HASH_ALGORITHMS.indexOf(algo) === -1) {
+    throw new Error("Unsupported hash algorithm: " + algo);
+  }
+
+  if (typeof content !== "string") {
+    throw new TypeError("content must be a string");
+  }
+
+  var digest = crypto.createHash(algo).update(content, "utf8").digest("base64");
+  return "'" + algo + "-" + digest + "'";
+}
+
+function getReportingEndpointsHeader(endpoints) {
+  if (!endpoints || typeof endpoints !== "object" || Array.isArray(endpoints)) {
+    throw new TypeError("endpoints must be an object");
+  }
+
+  return Object.keys(endpoints)
+    .map(function (name) {
+      return name + '="' + endpoints[name] + '"';
+    })
+    .join(", ");
+}
+
+function createNonceMiddleware(options) {
+  options = options || {};
+  var localKey = options.localKey || "cspNonce";
+  var rawKey = options.rawKey || "nonce";
+  var byteLength = options.byteLength;
+
+  return function nonceMiddleware(req, res, next) {
+    var nonce = generateNonce(byteLength);
+    res.locals[rawKey] = nonce;
+    res.locals[localKey] = nonce;
+    next();
+  };
+}
+
+function nonceDirective(localKey) {
+  var key = localKey || "cspNonce";
+
+  return function resolveNonce(req, res) {
+    var value = res.locals[key];
+
+    if (value === undefined || value === null || value === "") {
+      throw new Error("Missing nonce in res.locals." + key);
+    }
+
+    return formatNonce(value);
+  };
+}
+
+function appendUnique(existing, additions) {
+  var values = existing.slice();
+
+  additions.forEach(function (entry) {
+    if (values.indexOf(entry) === -1) {
+      values.push(entry);
+    }
+  });
+
+  return values;
+}
+
+function resolveProfileOptions(options) {
+  options = options || {};
+  var resolved = Object.assign({}, options);
+  var profile = resolved.profile || "strict";
+
+  if (SUPPORTED_PROFILES.indexOf(profile) === -1) {
+    throw new Error(
+      "Unknown CSP profile: " + profile + ". Expected one of: " + SUPPORTED_PROFILES.join(", ")
+    );
+  }
+
+  delete resolved.profile;
+
+  if (profile === "strict-dynamic" || resolved.strictDynamic === true) {
+    resolved.scripts = appendUnique(normalizeOptionArray(resolved, "scripts"), [
+      STRICT_DYNAMIC,
+    ]);
+    delete resolved.strictDynamic;
+  }
+
+  if (profile === "development") {
+    resolved.connect = appendUnique(
+      normalizeOptionArray(resolved, "connect"),
+      DEVELOPMENT_CONNECT_SOURCES
+    );
+
+    if (resolved.scriptAttrs === undefined) {
+      resolved.scriptAttrs = [NONE];
+    }
+
+    if (resolved.styleAttrs === undefined) {
+      resolved.styleAttrs = ["'unsafe-inline'"];
+    }
+  }
+
+  return resolved;
 }
 
 function normalizeOptionArray(options, key) {
@@ -59,18 +193,18 @@ function withSelfAndNonce(sources, nonce, includeNonce) {
   var values = [SELF];
 
   if (includeNonce && nonce !== undefined && nonce !== null && nonce !== "") {
-    values.push(nonce);
+    values.push(typeof nonce === "function" ? nonce : formatNonceValue(nonce));
   }
 
   return values.concat(sources);
 }
 
-function assignDirective(directives, key, value) {
-  if (value === undefined || value === null) {
-    return;
+function formatNonceValue(nonce) {
+  if (typeof nonce === "function") {
+    return nonce;
   }
 
-  directives[key] = value;
+  return formatNonce(nonce);
 }
 
 function assignFetchDirective(
@@ -85,14 +219,24 @@ function assignFetchDirective(
     return;
   }
 
-  directives[key] = withSelfAndNonce(sources, nonce, includeNonce);
+  var values = [SELF];
+
+  if (includeNonce && nonce !== undefined && nonce !== null && nonce !== "") {
+    if (typeof nonce === "function") {
+      values.push(nonce);
+    } else {
+      values.push(formatNonce(nonce));
+    }
+  }
+
+  directives[key] = values.concat(sources);
 }
 
 /*
   Build a Helmet-compatible directives object for contentSecurityPolicy.
 */
 function getDirectives(nonce, options) {
-  options = options || {};
+  options = resolveProfileOptions(options);
 
   DEFAULT_OPTION_ARRAYS.forEach(function (key) {
     if (

--- a/tests/nonce.test.js
+++ b/tests/nonce.test.js
@@ -1,6 +1,11 @@
 import {
+  createNonceMiddleware,
+  formatNonce,
   generateNonce,
   getDirectives,
+  getReportingEndpointsHeader,
+  hashSource,
+  nonceDirective,
 } from "../index.js";
 
 describe("generateNonce", () => {
@@ -25,14 +30,62 @@ describe("generateNonce", () => {
   });
 });
 
+describe("formatNonce", () => {
+  it("should wrap a raw nonce in single quotes", () => {
+    expect(formatNonce("abc123")).toBe("'nonce-abc123'");
+  });
+
+  it("should accept an already quoted nonce", () => {
+    expect(formatNonce("'nonce-abc123'")).toBe("'nonce-abc123'");
+  });
+});
+
+describe("hashSource", () => {
+  it("should generate a sha256 source expression", () => {
+    const hash = hashSource("console.log('hi')");
+
+    expect(hash).toMatch(/^'sha256-[A-Za-z0-9+/]+='$/);
+    expect(hashSource("console.log('hi')")).toBe(hash);
+  });
+});
+
+describe("getReportingEndpointsHeader", () => {
+  it("should format reporting endpoints for the Reporting-Endpoints header", () => {
+    expect(
+      getReportingEndpointsHeader({
+        csp: "https://example.com/csp-report",
+        default: "https://example.com/default-report",
+      })
+    ).toBe(
+      'csp="https://example.com/csp-report", default="https://example.com/default-report"'
+    );
+  });
+});
+
+describe("createNonceMiddleware and nonceDirective", () => {
+  it("should attach a nonce to res.locals and resolve a Helmet directive", () => {
+    const middleware = createNonceMiddleware();
+    const req = {};
+    const res = { locals: {} };
+
+    middleware(req, res, () => {});
+
+    const directive = nonceDirective()(req, res);
+
+    expect(res.locals.nonce).toMatch(/^[0-9a-f]+$/i);
+    expect(res.locals.cspNonce).toBe(res.locals.nonce);
+    expect(directive).toBe(formatNonce(res.locals.nonce));
+  });
+});
+
 describe("getDirectives", () => {
   it("should return secure defaults when no options are provided", () => {
-    const directives = getDirectives("test-nonce");
+    const directives = getDirectives("abc123");
 
     expect(directives).toEqual({
       defaultSrc: ["'self'"],
-      scriptSrc: ["'self'", "test-nonce"],
-      styleSrc: ["'self'", "test-nonce"],
+      scriptSrc: ["'self'", "'nonce-abc123'"],
+      styleSrc: ["'self'", "'nonce-abc123'"],
       fontSrc: ["'self'"],
       connectSrc: ["'self'"],
       frameSrc: ["'self'"],
@@ -69,12 +122,12 @@ describe("getDirectives", () => {
       upgradeInsecureRequests: true,
     };
 
-    const directives = getDirectives("test-nonce", options);
+    const directives = getDirectives("abc123", options);
 
     expect(directives).toEqual({
       defaultSrc: ["'self'"],
-      scriptSrc: ["'self'", "test-nonce", "https://cdn.example.com"],
-      styleSrc: ["'self'", "test-nonce", "https://fonts.googleapis.com"],
+      scriptSrc: ["'self'", "'nonce-abc123'", "https://cdn.example.com"],
+      styleSrc: ["'self'", "'nonce-abc123'", "https://fonts.googleapis.com"],
       fontSrc: ["'self'", "https://fonts.gstatic.com"],
       connectSrc: ["'self'", "https://api.example.com"],
       frameSrc: ["'self'", "https://www.google.com/recaptcha/"],
@@ -83,9 +136,9 @@ describe("getDirectives", () => {
       manifestSrc: ["'self'", "https://cdn.example.com"],
       mediaSrc: ["'self'", "https://media.example.com"],
       childSrc: ["'self'", "https://child.example.com"],
-      scriptSrcElem: ["'self'", "test-nonce", "'strict-dynamic'"],
+      scriptSrcElem: ["'self'", "'nonce-abc123'", "'strict-dynamic'"],
       scriptSrcAttr: ["'self'", "'none'"],
-      styleSrcElem: ["'self'", "test-nonce", "'unsafe-inline'"],
+      styleSrcElem: ["'self'", "'nonce-abc123'", "'unsafe-inline'"],
       styleSrcAttr: ["'self'", "'unsafe-hashes'"],
       webrtc: ["'self'"],
       trustedTypes: ["default"],
@@ -101,8 +154,32 @@ describe("getDirectives", () => {
     });
   });
 
+  it("should apply the strict-dynamic profile", () => {
+    const directives = getDirectives("abc123", { profile: "strict-dynamic" });
+
+    expect(directives.scriptSrc).toEqual([
+      "'self'",
+      "'nonce-abc123'",
+      "'strict-dynamic'",
+    ]);
+  });
+
+  it("should apply the development profile", () => {
+    const directives = getDirectives("abc123", { profile: "development" });
+
+    expect(directives.connectSrc).toEqual([
+      "'self'",
+      "ws:",
+      "wss:",
+      "http://localhost:*",
+      "https://localhost:*",
+    ]);
+    expect(directives.scriptSrcAttr).toEqual(["'self'", "'none'"]);
+    expect(directives.styleSrcAttr).toEqual(["'self'", "'unsafe-inline'"]);
+  });
+
   it("should reject non-array option values", () => {
-    expect(() => getDirectives("test-nonce", { scripts: "bad" })).toThrow(
+    expect(() => getDirectives("abc123", { scripts: "bad" })).toThrow(
       "options.scripts must be an array when provided"
     );
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Second of three PRs for **nonce-simple 2.0.0**. Builds on PR 1/3 with modern nonce workflows, policy presets, and reporting helpers.

**Depends on:** #4

## Changes

### Policy presets (Phase 3)
- `profile: 'strict'` (default) — secure baseline
- `profile: 'strict-dynamic'` — appends `'strict-dynamic'` to `script-src`
- `profile: 'development'` — relaxes local WebSocket/localhost `connect-src` and inline style attributes
- `strictDynamic: true` option as an alternative to the profile

### Helpers (Phase 3)
- `formatNonce(nonce)` — returns `'nonce-…'` quoted source expression
- `hashSource(content, algorithm?)` — builds `'sha256-…'` CSP hash sources
- `createNonceMiddleware(options?)` — Express middleware to populate `res.locals`
- `nonceDirective(localKey?)` — Helmet-compatible directive resolver function

### Reporting (Phase 4)
- `getReportingEndpointsHeader(endpoints)` — builds `Reporting-Endpoints` header values for use with `report-to`

### Behavior
- `getDirectives` now formats raw nonce values as quoted `'nonce-…'` expressions automatically

## Next PR
- **PR 3/3:** Full TypeScript types, README overhaul, CHANGELOG, final `2.0.0` release
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c32dd9a8-4835-465c-9a70-ba1c9900fed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c32dd9a8-4835-465c-9a70-ba1c9900fed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

